### PR TITLE
Fix fcitx5 dependency: PyGstObject version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
   "soundfile==0.13.1",
   "funasr_onnx==0.4.1",
   "jieba==0.42.1",
-  "PyGObject>=3.42.0,<3.51",
+  "PyGObject==3.42.0",
   "modelscope==1.30.0",
   "torch>=2.9.1",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ funasr_onnx==0.4.1
 jieba==0.42.1
 
 # IBus Python 绑定 (Linux 必需)
-PyGObject>=3.42.0,<3.51
+PyGObject==3.42.0
 
 # 模型下载 (推荐)
 modelscope==1.30.0

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11, <3.13"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -706,12 +706,12 @@ wheels = [
 
 [[package]]
 name = "pygobject"
-version = "3.50.2"
+version = "3.42.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pycairo" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a7/5d/f2946cc6c1baf56dee6e942af8cfa16472538a8ad9d780d9f484e7554288/pygobject-3.50.2.tar.gz", hash = "sha256:ece6b860aab77cb649fdfc6e88d8a83765e7a62f7ffd39a628d6e2a0d397a7ff", size = 1085854, upload-time = "2025-10-18T13:44:45.634Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/72/48cfdd7a0caf3c27f392d2657731ac6f7c3c1c0a60bfeba3e1ba9ffa7ba9/PyGObject-3.42.0.tar.gz", hash = "sha256:b9803991ec0b0b4175e81fee0ad46090fa7af438fe169348a9b18ae53447afcd", size = 716094, upload-time = "2021-09-19T10:21:14.777Z" }
 
 [[package]]
 name = "pyreadline3"
@@ -1065,7 +1065,7 @@ requires-dist = [
     { name = "jieba", specifier = "==0.42.1" },
     { name = "librosa", specifier = "==0.11.0" },
     { name = "modelscope", specifier = "==1.30.0" },
-    { name = "pygobject", specifier = ">=3.42.0,<3.51" },
+    { name = "pygobject", specifier = "==3.42.0" },
     { name = "pyrime", marker = "extra == 'full'", specifier = ">=0.2.1" },
     { name = "pyrime", marker = "extra == 'rime'", specifier = ">=0.2.1" },
     { name = "sounddevice", specifier = "==0.5.2" },


### PR DESCRIPTION
PyGstObject>3.42.0 has compatibility problem with audioread. Use PyGstObject==3.42.0.

Error with PyGstObject > 3.42.0 when installing:
```正在初始化语音识别引擎...
（首次运行会下载模型，约 500MB，请稍候...）

✓ 识别引擎初始化成功

重采样音频: 44100Hz -> 16000Hz
正在识别...
ERROR:app.funasr_server:音频转录失败: Argument 1 does not allow None as a value
ERROR:app.funasr_server:Traceback (most recent call last):
  File "/home/user/VocoType-linux/app/funasr_server.py", line 498, in transcribe_audio
    asr_result = self.asr_model([audio_path_for_asr])
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/.local/share/vocotype-fcitx5/.venv/lib/python3.12/site-packages/funasr_onnx/paraformer_bin.py", line 99, in __call__
    waveform_list = self.load_data(wav_content, self.frontend.opts.frame_opts.samp_freq)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/.local/share/vocotype-fcitx5/.venv/lib/python3.12/site-packages/funasr_onnx/paraformer_bin.py", line 189, in load_data
    return [load_wav(path) for path in wav_content]
            ^^^^^^^^^^^^^^
  File "/home/user/.local/share/vocotype-fcitx5/.venv/lib/python3.12/site-packages/funasr_onnx/paraformer_bin.py", line 179, in load_wav
    waveform, _ = librosa.load(path, sr=fs)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/.local/share/vocotype-fcitx5/.venv/lib/python3.12/site-packages/librosa/core/audio.py", line 170, in load
    if isinstance(path, tuple(audioread.available_backends())):
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/.local/share/vocotype-fcitx5/.venv/lib/python3.12/site-packages/audioread/__init__.py", line 89, in available_backends
    from . import gstdec
  File "/home/user/.local/share/vocotype-fcitx5/.venv/lib/python3.12/site-packages/audioread/gstdec.py", line 117, in <module>
    Gst.init(None)
TypeError: Argument 1 does not allow None as a value

```