### PR TITLE
audio: pick the server-virtual default mic and resample without aliasing

### DIFF
--- a/app/audio_capture.py
+++ b/app/audio_capture.py
@@ -10,6 +10,8 @@ from typing import Optional
 import numpy as np
 import sounddevice as sd
 
+from app.audio_utils import resolve_default_input_device
+
 
 logger = logging.getLogger(__name__)
 
@@ -50,12 +52,13 @@ class AudioCapture:
                 return
 
             self.flush()
-            self._stream = self._create_stream(self.device)
+            device = self.device if self.device is not None else resolve_default_input_device()
+            self._stream = self._create_stream(device)
             try:
                 self._stream.start()
             except Exception:
                 self._stream.close()
-                self._stream = self._create_stream(self._fallback_device())
+                self._stream = self._create_stream(resolve_default_input_device())
                 self._stream.start()
 
             self._running = True
@@ -99,19 +102,6 @@ class AudioCapture:
             msg = f"无法创建音频输入流: {exc}"
             logger.error(msg)
             raise AudioCaptureError(msg) from exc
-
-    def _fallback_device(self) -> Optional[int]:
-        try:
-            devices = sd.query_devices()
-            for idx, info in enumerate(devices):
-                if info.get("max_input_channels", 0) > 0:
-                    logger.warning(
-                        "回退至输入设备 #%s (%s)", idx, info.get("name", "unknown")
-                    )
-                    return idx
-        except Exception as exc:
-            logger.error("查询音频设备失败: %s", exc)
-        return None
 
     def _callback(self, in_data, frames, time, status):  # type: ignore[override]
         if status:

--- a/app/audio_capture.py
+++ b/app/audio_capture.py
@@ -52,14 +52,36 @@ class AudioCapture:
                 return
 
             self.flush()
-            device = self.device if self.device is not None else resolve_default_input_device()
-            self._stream = self._create_stream(device)
-            try:
-                self._stream.start()
-            except Exception:
-                self._stream.close()
-                self._stream = self._create_stream(resolve_default_input_device())
-                self._stream.start()
+            primary_device = (
+                self.device if self.device is not None else resolve_default_input_device()
+            )
+            fallback_device = resolve_default_input_device(exclude=(primary_device,))
+            candidates = [primary_device]
+            if fallback_device is not None and fallback_device != primary_device:
+                candidates.append(fallback_device)
+
+            last_error: Exception | None = None
+            for device in candidates:
+                stream: Optional[sd.RawInputStream] = None
+                try:
+                    stream = self._create_stream(device)
+                    stream.start()
+                except Exception as exc:
+                    last_error = exc
+                    if stream is not None:
+                        try:
+                            stream.close()
+                        except Exception:
+                            logger.debug("关闭失败的音频流时出错", exc_info=True)
+                    logger.warning("启动输入设备 %s 失败: %s", device, exc)
+                    continue
+
+                self._stream = stream
+                break
+            else:
+                if isinstance(last_error, AudioCaptureError):
+                    raise last_error
+                raise AudioCaptureError(f"无法启动音频输入流: {last_error}") from last_error
 
             self._running = True
             logger.info(

--- a/app/audio_utils.py
+++ b/app/audio_utils.py
@@ -17,16 +17,63 @@ SAMPLE_RATE = 16000
 DEFAULT_NATIVE_SAMPLE_RATE = 44100
 
 
-def load_audio_config() -> tuple[int | str | None, int]:
-    """从配置文件加载音频设备配置
+def resolve_default_input_device() -> int | None:
+    """挑选用户实际的默认麦克风。
+
+    优先级：
+      1. ALSA "default" / "pulse" 这两个由 PipeWire/PulseAudio 注入的虚拟
+         PCM，跟随 wpctl/pavucontrol 选择的默认源。
+      2. PortAudio 自己认定的 default (sd.default.device[0])。
+      3. 第一个有输入通道的设备（兜底）。
+    """
+    import sounddevice as sd
+
+    try:
+        devices = list(sd.query_devices())
+    except Exception as exc:
+        logger.warning("查询音频设备列表失败: %s", exc)
+        return None
+
+    for preferred in ("default", "pulse"):
+        for idx, info in enumerate(devices):
+            if info.get("name") == preferred and info.get("max_input_channels", 0) > 0:
+                logger.info("使用服务器虚拟设备 #%s (%s)", idx, preferred)
+                return idx
+
+    try:
+        pa_default = sd.default.device[0]
+        if pa_default is not None and pa_default >= 0:
+            info = devices[pa_default]
+            if info.get("max_input_channels", 0) > 0:
+                logger.info(
+                    "使用 PortAudio 默认设备 #%s (%s)",
+                    pa_default,
+                    info.get("name", "unknown"),
+                )
+                return pa_default
+    except Exception:
+        pass
+
+    for idx, info in enumerate(devices):
+        if info.get("max_input_channels", 0) > 0:
+            logger.info("回退至输入设备 #%s (%s)", idx, info.get("name", "unknown"))
+            return idx
+
+    logger.warning("没有发现可用的音频输入设备")
+    return None
+
+
+def load_audio_config() -> tuple[int | str | None, int | None]:
+    """从配置文件加载音频设备配置。
 
     Returns:
-        (device, sample_rate): 设备（可能为 None、整数 ID 或字符串名称）和采样率
+        (device, sample_rate): 没有配置文件时返回 (None, None)，让调用方使用
+        服务器虚拟设备并直接请求 16 kHz；配置文件存在则按内容返回。
     """
     config_file = Path.home() / ".config" / "vocotype" / "audio.conf"
     if not config_file.exists():
-        logger.warning("音频配置文件不存在: %s，使用默认设备", config_file)
-        return None, DEFAULT_NATIVE_SAMPLE_RATE
+        logger.info("未找到 %s，使用系统默认输入设备", config_file)
+        return None, None
 
     try:
         import configparser
@@ -47,7 +94,7 @@ def load_audio_config() -> tuple[int | str | None, int]:
         return device_id, sample_rate
     except Exception as e:
         logger.warning("读取音频配置失败: %s，使用默认设备", e)
-        return None, DEFAULT_NATIVE_SAMPLE_RATE
+        return None, None
 
 
 def resample_audio(audio: np.ndarray, orig_sr: int, target_sr: int) -> np.ndarray:
@@ -63,7 +110,14 @@ def resample_audio(audio: np.ndarray, orig_sr: int, target_sr: int) -> np.ndarra
     """
     if orig_sr == target_sr:
         return audio
-    duration = len(audio) / orig_sr
-    target_length = int(duration * target_sr)
-    indices = np.linspace(0, len(audio) - 1, target_length)
-    return np.interp(indices, np.arange(len(audio)), audio.astype(np.float32)).astype(np.int16)
+
+    import librosa
+
+    float_audio = audio.astype(np.float32) / 32768.0
+    resampled = librosa.resample(
+        float_audio,
+        orig_sr=orig_sr,
+        target_sr=target_sr,
+        res_type="soxr_hq",
+    )
+    return np.clip(resampled * 32768.0, -32768, 32767).astype(np.int16)

--- a/app/audio_utils.py
+++ b/app/audio_utils.py
@@ -17,7 +17,9 @@ SAMPLE_RATE = 16000
 DEFAULT_NATIVE_SAMPLE_RATE = 44100
 
 
-def resolve_default_input_device() -> int | None:
+def resolve_default_input_device(
+    *, exclude: tuple[int | str | None, ...] = ()
+) -> int | None:
     """挑选用户实际的默认麦克风。
 
     优先级：
@@ -25,6 +27,9 @@ def resolve_default_input_device() -> int | None:
          PCM，跟随 wpctl/pavucontrol 选择的默认源。
       2. PortAudio 自己认定的 default (sd.default.device[0])。
       3. 第一个有输入通道的设备（兜底）。
+
+    ``exclude`` 同时匹配设备 ID 和设备名称，用于首次打开失败后选择一个
+    真正不同的回退设备。
     """
     import sounddevice as sd
 
@@ -34,17 +39,27 @@ def resolve_default_input_device() -> int | None:
         logger.warning("查询音频设备列表失败: %s", exc)
         return None
 
+    excluded = {item for item in exclude if item is not None}
+
+    def is_available(idx: int, info: dict) -> bool:
+        return (
+            info.get("max_input_channels", 0) > 0
+            and idx not in excluded
+            and info.get("name") not in excluded
+        )
+
     for preferred in ("default", "pulse"):
         for idx, info in enumerate(devices):
-            if info.get("name") == preferred and info.get("max_input_channels", 0) > 0:
+            if info.get("name") == preferred and is_available(idx, info):
                 logger.info("使用服务器虚拟设备 #%s (%s)", idx, preferred)
                 return idx
 
     try:
-        pa_default = sd.default.device[0]
-        if pa_default is not None and pa_default >= 0:
+        pa_default_raw = sd.default.device[0]
+        pa_default = int(pa_default_raw) if pa_default_raw is not None else -1
+        if 0 <= pa_default < len(devices):
             info = devices[pa_default]
-            if info.get("max_input_channels", 0) > 0:
+            if is_available(pa_default, info):
                 logger.info(
                     "使用 PortAudio 默认设备 #%s (%s)",
                     pa_default,
@@ -55,7 +70,7 @@ def resolve_default_input_device() -> int | None:
         pass
 
     for idx, info in enumerate(devices):
-        if info.get("max_input_channels", 0) > 0:
+        if is_available(idx, info):
             logger.info("回退至输入设备 #%s (%s)", idx, info.get("name", "unknown"))
             return idx
 

--- a/fcitx5/backend/audio_recorder.py
+++ b/fcitx5/backend/audio_recorder.py
@@ -50,6 +50,18 @@ logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
 logger = logging.getLogger(__name__)
 
 
+def resolve_requested_sample_rate(
+    cli_sample_rate: int | None,
+    configured_sample_rate: int | None,
+) -> int:
+    """Resolve CLI/config/default sample rate without using a magic sentinel."""
+    if cli_sample_rate is not None:
+        return cli_sample_rate
+    if configured_sample_rate:
+        return configured_sample_rate
+    return SAMPLE_RATE
+
+
 class AudioRecorder:
     """音频录制器"""
 
@@ -211,8 +223,8 @@ def main():
     parser.add_argument(
         '--sample-rate',
         type=int,
-        default=44100,
-        help='Sample rate (default: 44100)'
+        default=None,
+        help='Sample rate (default: configured rate or 16000)'
     )
     args = parser.parse_args()
 
@@ -221,12 +233,9 @@ def main():
     device = args.device if args.device is not None else configured_device
     if isinstance(device, str) and device.isdigit():
         device = int(device)
-    # Ask the sound server for 16 kHz directly so PipeWire/PulseAudio resample
-    # with proper anti-aliasing. Honour an explicit configured rate if set.
-    if args.sample_rate != 44100:
-        sample_rate = args.sample_rate
-    else:
-        sample_rate = configured_sr if configured_sr else SAMPLE_RATE
+    # Ask the sound server for 16 kHz directly when no rate was configured.
+    # An explicit --sample-rate value, including 44100, must always win.
+    sample_rate = resolve_requested_sample_rate(args.sample_rate, configured_sr)
 
     # 录音
     recorder = AudioRecorder(device, sample_rate)

--- a/fcitx5/backend/audio_recorder.py
+++ b/fcitx5/backend/audio_recorder.py
@@ -38,7 +38,12 @@ def discover_project_root() -> Path:
 PROJECT_ROOT = discover_project_root()
 sys.path.insert(0, str(PROJECT_ROOT))
 
-from app.audio_utils import load_audio_config, resample_audio, SAMPLE_RATE
+from app.audio_utils import (
+    load_audio_config,
+    resample_audio,
+    resolve_default_input_device,
+    SAMPLE_RATE,
+)
 from app.wave_writer import write_wav
 
 logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
@@ -67,16 +72,7 @@ class AudioRecorder:
             except Exception as exc:
                 logger.warning("查询设备 %s 失败: %s", self.device, exc)
 
-        try:
-            devices = sd.query_devices()
-            for idx, info in enumerate(devices):
-                if info.get("max_input_channels", 0) > 0:
-                    logger.info("回退至输入设备 #%s (%s)", idx, info.get("name", "unknown"))
-                    return idx
-        except Exception as exc:
-            logger.warning("查询输入设备列表失败: %s", exc)
-
-        return None
+        return resolve_default_input_device()
 
     def _resolve_sample_rate(self, device, preferred):
         """选择可用采样率"""
@@ -225,7 +221,12 @@ def main():
     device = args.device if args.device is not None else configured_device
     if isinstance(device, str) and device.isdigit():
         device = int(device)
-    sample_rate = args.sample_rate if args.sample_rate != 44100 else configured_sr
+    # Ask the sound server for 16 kHz directly so PipeWire/PulseAudio resample
+    # with proper anti-aliasing. Honour an explicit configured rate if set.
+    if args.sample_rate != 44100:
+        sample_rate = args.sample_rate
+    else:
+        sample_rate = configured_sr if configured_sr else SAMPLE_RATE
 
     # 录音
     recorder = AudioRecorder(device, sample_rate)

--- a/test/test_audio_capture.py
+++ b/test/test_audio_capture.py
@@ -1,0 +1,43 @@
+from app.audio_capture import AudioCapture
+
+
+def test_audio_capture_retries_with_distinct_fallback_device(monkeypatch):
+    resolve_calls = []
+
+    def fake_resolve_default_input_device(*, exclude=()):
+        resolve_calls.append(exclude)
+        return 5 if not exclude else 6
+
+    monkeypatch.setattr(
+        "app.audio_capture.resolve_default_input_device",
+        fake_resolve_default_input_device,
+    )
+
+    streams = []
+
+    class FakeStream:
+        def __init__(self, device):
+            self.device = device
+            self.closed = False
+            streams.append(self)
+
+        def start(self):
+            if self.device == 5:
+                raise RuntimeError("primary failed")
+
+        def close(self):
+            self.closed = True
+
+        def stop(self):
+            pass
+
+    capture = AudioCapture(sample_rate=16000, block_ms=20)
+    monkeypatch.setattr(capture, "_create_stream", lambda device: FakeStream(device))
+
+    capture.start()
+
+    assert resolve_calls == [(), (5,)]
+    assert [stream.device for stream in streams] == [5, 6]
+    assert streams[0].closed is True
+    assert capture._stream is streams[1]
+    assert capture._running is True

--- a/test/test_audio_utils.py
+++ b/test/test_audio_utils.py
@@ -1,0 +1,39 @@
+import numpy as np
+import sounddevice as sd
+
+from app.audio_utils import resolve_default_input_device, resample_audio
+
+
+def test_resolve_default_input_device_prefers_server_virtual_default(monkeypatch):
+    devices = [
+        {"name": "Built-in Mic", "max_input_channels": 2},
+        {"name": "pulse", "max_input_channels": 32},
+        {"name": "default", "max_input_channels": 32},
+    ]
+    monkeypatch.setattr(sd, "query_devices", lambda *args, **kwargs: devices)
+    monkeypatch.setattr(sd.default, "device", (0, 0))
+
+    assert resolve_default_input_device() == 2
+    assert resolve_default_input_device(exclude=(2,)) == 1
+    assert resolve_default_input_device(exclude=("default", "pulse")) == 0
+
+
+def test_resolve_default_input_device_uses_portaudio_default(monkeypatch):
+    devices = [
+        {"name": "Built-in Mic", "max_input_channels": 2},
+        {"name": "USB Mic", "max_input_channels": 1},
+    ]
+    monkeypatch.setattr(sd, "query_devices", lambda *args, **kwargs: devices)
+    monkeypatch.setattr(sd.default, "device", (1, 0))
+
+    assert resolve_default_input_device() == 1
+
+
+def test_resample_audio_preserves_int16_and_expected_length():
+    source = (np.sin(np.linspace(0, 20 * np.pi, 4410)) * 20000).astype(np.int16)
+
+    result = resample_audio(source, orig_sr=44100, target_sr=16000)
+
+    assert result.dtype == np.int16
+    assert len(result) == 1600
+    assert np.max(np.abs(result.astype(np.int32))) <= 32767

--- a/test/test_fcitx_audio_recorder.py
+++ b/test/test_fcitx_audio_recorder.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1] / "fcitx5" / "backend" / "audio_recorder.py"
+)
+SPEC = importlib.util.spec_from_file_location("vocotype_fcitx_audio_recorder", MODULE_PATH)
+assert SPEC and SPEC.loader
+audio_recorder = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = audio_recorder
+SPEC.loader.exec_module(audio_recorder)
+
+
+def test_explicit_44100_sample_rate_is_honoured():
+    assert audio_recorder.resolve_requested_sample_rate(44100, 16000) == 44100
+
+
+def test_configured_sample_rate_is_used_when_cli_is_absent():
+    assert audio_recorder.resolve_requested_sample_rate(None, 48000) == 48000
+
+
+def test_16khz_is_used_when_neither_cli_nor_config_is_present():
+    assert (
+        audio_recorder.resolve_requested_sample_rate(None, None)
+        == audio_recorder.SAMPLE_RATE
+        == 16000
+    )


### PR DESCRIPTION
Closes #5.

On Linux, sounddevice (PortAudio) only ever sees ALSA devices. PortAudio has no native PipeWire/PulseAudio host API, so the way to follow the user's default mic selection from \`wpctl\` / \`pavucontrol\` is to open the ALSA \`default\` or \`pulse\` virtual PCM that PipeWire and PulseAudio inject into ALSA. The current fallback grabs the first device with input channels, which on most desktops is a hardware capture card like \`hw:0,0\`, not the one the user actually selected. Recording from the wrong jack and then linearly resampling 44.1 kHz to 16 kHz with \`np.interp\` (no anti-aliasing low-pass) is what surfaces as issue #5.

### Changes

1. **`resolve_default_input_device()`** in `app/audio_utils.py` picks the input device by priority: explicit override, then ALSA \`default\`, then ALSA \`pulse\`, then \`sd.default.device[0]\`, then the first device with input channels. \`fcitx5/backend/audio_recorder.py\` and \`app/audio_capture.py\` both delegate to it.

2. **Request 16 kHz from the sound server.** PipeWire and PulseAudio carry band-limited resamplers, so the client does not need to resample. \`load_audio_config()\` now returns \`(None, None)\` when no \`audio.conf\` exists, signalling "use server default rate", and \`audio_recorder\` defaults its target to \`SAMPLE_RATE\` (16 kHz).

3. **Anti-aliased fallback resampling.** Replace \`np.interp\` with \`librosa.resample(res_type="soxr_hq")\`. \`soxr_hq\` provides FIR low-pass plus polyphase filtering. \`librosa\` is already a runtime dependency.

### Test

Tested locally with PipeWire 1.0.x on Gentoo. Before the patch, swapping default sources in \`pavucontrol\` had no effect on what vocotype recorded (it stayed on \`hw:0,0\`) and recognition was largely garbage. After the patch, the recorded jack tracks the \`pavucontrol\` default and recognition matches the spoken Chinese.