### PR TITLE
Update clone command with directory name for IBus and Fcitx

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -40,8 +40,8 @@ https://github.com/user-attachments/assets/94772920-0f9e-4dff-8da5-c9026eb23256
 ### IBus 版本
 
 ```bash
-git clone https://github.com/LeonardNJU/VocoType-linux.git vocotype-cli
-cd vocotype-cli
+git clone https://github.com/LeonardNJU/VocoType-linux.git
+cd VocoType-linux
 ./scripts/install-ibus.sh
 ibus restart
 ```
@@ -57,8 +57,8 @@ ibus restart
 ### Fcitx 5 版本
 
 ```bash
-git clone https://github.com/LeonardNJU/VocoType-linux.git vocotype-cli
-cd vocotype-cli
+git clone https://github.com/LeonardNJU/VocoType-linux.git
+cd VocoType-linux
 bash fcitx5/scripts/install-fcitx5.sh
 fcitx5 -r
 ```

--- a/readme.md
+++ b/readme.md
@@ -40,7 +40,7 @@ https://github.com/user-attachments/assets/94772920-0f9e-4dff-8da5-c9026eb23256
 ### IBus 版本
 
 ```bash
-git clone https://github.com/LeonardNJU/VocoType-linux.git
+git clone https://github.com/LeonardNJU/VocoType-linux.git vocotype-cli
 cd vocotype-cli
 ./scripts/install-ibus.sh
 ibus restart
@@ -57,7 +57,7 @@ ibus restart
 ### Fcitx 5 版本
 
 ```bash
-git clone https://github.com/LeonardNJU/VocoType-linux.git
+git clone https://github.com/LeonardNJU/VocoType-linux.git vocotype-cli
 cd vocotype-cli
 bash fcitx5/scripts/install-fcitx5.sh
 fcitx5 -r


### PR DESCRIPTION
文档路径有点小问题，仓库名现在是VocoType-linux，应克隆到vocotype-cli