### PR TITLE
test: verify PyGObject 3.50 GStreamer compatibility

### DIFF
--- a/.github/workflows/gst-compat.yml
+++ b/.github/workflows/gst-compat.yml
@@ -1,0 +1,39 @@
+name: PyGObject 3.50 compatibility
+
+on:
+  pull_request:
+    paths:
+      - "app/funasr_server.py"
+      - "tests/test_gst_pygobject_compat.py"
+      - ".github/workflows/gst-compat.yml"
+      - "pyproject.toml"
+      - "uv.lock"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  gst-compat:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libportaudio2 portaudio19-dev \
+            libcairo2-dev libgirepository1.0-dev gir1.2-gstreamer-1.0 \
+            gstreamer1.0-plugins-base pkg-config cmake g++ \
+            libfcitx5core-dev nlohmann-json3-dev
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest "PyGObject==3.50.2"
+          python -m pip install -e .
+      - name: Reproduce and verify Gst.init compatibility
+        run: python -m pytest -q tests/test_gst_pygobject_compat.py

--- a/.github/workflows/gst-compat.yml
+++ b/.github/workflows/gst-compat.yml
@@ -12,6 +12,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   gst-compat:
@@ -37,4 +38,21 @@ jobs:
           python -m pip install -q pytest "PyGObject==3.50.2" >>/tmp/pip.log 2>&1 || { cat /tmp/pip.log; exit 1; }
           python -m pip install -q -e . >>/tmp/pip.log 2>&1 || { cat /tmp/pip.log; exit 1; }
       - name: Reproduce and verify Gst.init compatibility
-        run: python -m pytest -q -s tests/test_gst_pygobject_compat.py
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set +e
+          python -m pytest -q -s tests/test_gst_pygobject_compat.py > /tmp/gst-test.log 2>&1
+          status=$?
+          cat /tmp/gst-test.log
+          if [ "$status" -ne 0 ] && [ -n "${{ github.event.pull_request.number }}" ]; then
+            {
+              echo 'Focused PyGObject compatibility test failed:'
+              echo
+              echo '```text'
+              tail -n 80 /tmp/gst-test.log
+              echo '```'
+            } > /tmp/pr-comment.md
+            gh pr comment "${{ github.event.pull_request.number }}" --body-file /tmp/pr-comment.md
+          fi
+          exit "$status"

--- a/.github/workflows/gst-compat.yml
+++ b/.github/workflows/gst-compat.yml
@@ -24,16 +24,17 @@ jobs:
           cache: pip
       - name: Install system dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
+          sudo apt-get update -qq >/tmp/apt-update.log 2>&1 || { cat /tmp/apt-update.log; exit 1; }
+          sudo apt-get install -y -qq \
             libportaudio2 portaudio19-dev \
             libcairo2-dev libgirepository1.0-dev gir1.2-gstreamer-1.0 \
             gstreamer1.0-plugins-base pkg-config cmake g++ \
-            libfcitx5core-dev nlohmann-json3-dev
+            libfcitx5core-dev nlohmann-json3-dev \
+            >/tmp/apt-install.log 2>&1 || { cat /tmp/apt-install.log; exit 1; }
       - name: Install Python dependencies
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install pytest "PyGObject==3.50.2"
-          python -m pip install -e .
+          python -m pip install -q --upgrade pip >/tmp/pip.log 2>&1 || { cat /tmp/pip.log; exit 1; }
+          python -m pip install -q pytest "PyGObject==3.50.2" >>/tmp/pip.log 2>&1 || { cat /tmp/pip.log; exit 1; }
+          python -m pip install -q -e . >>/tmp/pip.log 2>&1 || { cat /tmp/pip.log; exit 1; }
       - name: Reproduce and verify Gst.init compatibility
-        run: python -m pytest -q tests/test_gst_pygobject_compat.py
+        run: python -m pytest -q -s tests/test_gst_pygobject_compat.py

--- a/tests/test_gst_pygobject_compat.py
+++ b/tests/test_gst_pygobject_compat.py
@@ -1,0 +1,52 @@
+import os
+from pathlib import Path
+import subprocess
+import sys
+import textwrap
+
+
+def test_pygobject_350_accepts_audioread_gst_init_none_after_vocotype_patch():
+    """Reproduce the PyGObject 3.50 failure, then verify VoCoType fixes it."""
+    repo_root = Path(__file__).resolve().parents[1]
+    script = textwrap.dedent(
+        """
+        import importlib.metadata
+
+        version = importlib.metadata.version("PyGObject")
+        assert version == "3.50.2", f"expected PyGObject 3.50.2, got {version}"
+
+        import gi
+
+        gi.require_version("Gst", "1.0")
+        from gi.repository import Gst
+
+        try:
+            Gst.init(None)
+        except TypeError:
+            pass
+        else:
+            raise AssertionError(
+                "test environment did not reproduce PyGObject 3.50 Gst.init(None) failure"
+            )
+
+        from app import funasr_server
+
+        patched_init = Gst.init
+        Gst.init(None)
+        Gst.init([])
+
+        funasr_server._patch_audioread_gstreamer_compatibility()
+        assert Gst.init is patched_init, "compatibility patch must be idempotent"
+        """
+    )
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(repo_root)
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr

--- a/tests/test_gst_pygobject_compat.py
+++ b/tests/test_gst_pygobject_compat.py
@@ -4,6 +4,18 @@ import subprocess
 import sys
 import textwrap
 
+import pytest
+
+
+def _require_gstreamer_typelib() -> None:
+    try:
+        import gi
+
+        gi.require_version("Gst", "1.0")
+        from gi.repository import Gst  # noqa: F401
+    except (ImportError, ValueError) as exc:
+        pytest.skip(f"GStreamer typelib is not installed: {exc}")
+
 
 def _run_isolated(script: str) -> subprocess.CompletedProcess[str]:
     repo_root = Path(__file__).resolve().parents[1]
@@ -21,6 +33,7 @@ def _run_isolated(script: str) -> subprocess.CompletedProcess[str]:
 
 def test_pygobject_350_gst_init_calls_remain_valid_after_vocotype_patch():
     """Exercise the real PyGObject/GStreamer binding available on the runner."""
+    _require_gstreamer_typelib()
     completed = _run_isolated(
         """
         import importlib.metadata
@@ -47,6 +60,7 @@ def test_pygobject_350_gst_init_calls_remain_valid_after_vocotype_patch():
 
 def test_gst_compatibility_patch_normalizes_none_for_strict_bindings():
     """Model the strict typelib behavior reported on affected distributions."""
+    _require_gstreamer_typelib()
     completed = _run_isolated(
         """
         import gi

--- a/tests/test_gst_pygobject_compat.py
+++ b/tests/test_gst_pygobject_compat.py
@@ -5,10 +5,23 @@ import sys
 import textwrap
 
 
-def test_pygobject_350_accepts_audioread_gst_init_none_after_vocotype_patch():
-    """Reproduce the PyGObject 3.50 failure, then verify VoCoType fixes it."""
+def _run_isolated(script: str) -> subprocess.CompletedProcess[str]:
     repo_root = Path(__file__).resolve().parents[1]
-    script = textwrap.dedent(
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(repo_root)
+    return subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(script)],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_pygobject_350_gst_init_calls_remain_valid_after_vocotype_patch():
+    """Exercise the real PyGObject/GStreamer binding available on the runner."""
+    completed = _run_isolated(
         """
         import importlib.metadata
 
@@ -19,16 +32,6 @@ def test_pygobject_350_accepts_audioread_gst_init_none_after_vocotype_patch():
 
         gi.require_version("Gst", "1.0")
         from gi.repository import Gst
-
-        try:
-            Gst.init(None)
-        except TypeError:
-            pass
-        else:
-            raise AssertionError(
-                "test environment did not reproduce PyGObject 3.50 Gst.init(None) failure"
-            )
-
         from app import funasr_server
 
         patched_init = Gst.init
@@ -39,14 +42,40 @@ def test_pygobject_350_accepts_audioread_gst_init_none_after_vocotype_patch():
         assert Gst.init is patched_init, "compatibility patch must be idempotent"
         """
     )
-    env = os.environ.copy()
-    env["PYTHONPATH"] = str(repo_root)
-    completed = subprocess.run(
-        [sys.executable, "-c", script],
-        cwd=repo_root,
-        env=env,
-        capture_output=True,
-        text=True,
-        check=False,
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
+def test_gst_compatibility_patch_normalizes_none_for_strict_bindings():
+    """Model the strict typelib behavior reported on affected distributions."""
+    completed = _run_isolated(
+        """
+        import gi
+
+        gi.require_version("Gst", "1.0")
+        from gi.repository import Gst
+        from app import funasr_server
+
+        calls = []
+
+        def strict_init(args):
+            if args is None:
+                raise TypeError("Argument 1 does not allow None as a value")
+            calls.append(args)
+            return "initialized"
+
+        Gst.init = strict_init
+        funasr_server._patch_audioread_gstreamer_compatibility()
+
+        assert Gst.init(None) == "initialized"
+        assert calls == [[]]
+
+        explicit_args = ["--gst-debug=2"]
+        assert Gst.init(explicit_args) == "initialized"
+        assert calls[-1] is explicit_args
+
+        patched_init = Gst.init
+        funasr_server._patch_audioread_gstreamer_compatibility()
+        assert Gst.init is patched_init, "compatibility patch must be idempotent"
+        """
     )
     assert completed.returncode == 0, completed.stdout + completed.stderr


### PR DESCRIPTION
Follow-up verification for #36.

## Why

PR #36 fixed `Gst.init(None)` for affected PyGObject/GStreamer combinations, but its added regression test covered only `None` ASR text rather than the core GStreamer compatibility path. The original pull-request workflow also did not execute because it required approval.

## What this adds

- A focused integration job pinned to `PyGObject==3.50.2` with the GStreamer typelib installed.
- A real-binding test confirming normal `Gst.init(None)` / `Gst.init([])` calls remain valid after importing VoCoType.
- A deterministic strict-binding regression test that models the reported `TypeError`, verifies `None` is converted to `[]`, verifies explicit arguments are passed through unchanged, and verifies the shim is idempotent.
- Graceful skips in the ordinary test matrix when the optional GStreamer typelib is absent; the focused job always installs it and therefore cannot skip these checks.

This PR contains verification infrastructure only. Merge only after both the focused compatibility job and the normal project CI pass.