### PR TITLE
fix: migrate legacy Fcitx profiles during repair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fcitx repair now removes stale legacy `vocotype` input-method references from the user profile, restores Rime as the group default when available, backs up the original profile, and distinguishes a discovered addon from an enabled addon before reporting success.
 - Ubuntu 22.04/24.04 now install a Python 3.12-compatible PyGObject release without requiring the newer `girepository-2.0` toolchain.
 - IBus 1.5.26 no longer fails to import when optional `OSK` and `SYNC_PROCESS_KEY` capability constants are absent.
 - The system-Python installer validates the complete FunASR ONNX runtime before installing the IBus launcher.

--- a/app/fcitx_session.py
+++ b/app/fcitx_session.py
@@ -1,9 +1,10 @@
-"""Fcitx desktop-session queries and safe replacement startup."""
+"""Fcitx desktop-session queries, migration, and safe replacement startup."""
 
 from __future__ import annotations
 
 import json
 import os
+import re
 import shutil
 import subprocess
 import time
@@ -12,12 +13,26 @@ from pathlib import Path
 from typing import Mapping
 
 FCITX_SERVICE = "org.fcitx.Fcitx5"
+FCITX_CONTROLLER_PATH = "/controller"
+FCITX_CONTROLLER_INTERFACE = "org.fcitx.Fcitx.Controller1"
+LEGACY_INPUT_METHOD = "vocotype"
+
+
 @dataclass(frozen=True)
 class FcitxRestartResult:
     success: bool
     message: str
     startup_log: str = ""
     owner: str | None = None
+
+
+@dataclass(frozen=True)
+class FcitxProfileMigrationResult:
+    changed: bool
+    profile: Path
+    backup: Path | None = None
+    removed_entries: int = 0
+    restored_defaults: tuple[tuple[str, str], ...] = ()
 
 
 def session_environment(base: Mapping[str, str] | None = None) -> dict[str, str]:
@@ -79,26 +94,279 @@ def query_fcitx_bus_owner() -> str | None:
     return str(owner) if owner else None
 
 
-def query_fcitx_addon_names() -> set[str] | None:
-    payload = _busctl_json_call(
-        [
-            FCITX_SERVICE,
-            "/controller",
-            "org.fcitx.Fcitx.Controller1",
-            "GetAddons",
-        ]
-    )
-    if payload is None:
+def parse_fcitx_addon_states(payload: object) -> dict[str, bool] | None:
+    """Parse GetAddons rows as ``uniqueName -> enabled``.
+
+    GetAddons lists every discoverable addon. Merely seeing ``vocotype`` in the
+    response does not mean it is enabled; the sixth field carries that state.
+    """
+
+    if not isinstance(payload, dict):
         return None
     try:
         rows = payload.get("data", [[]])[0]
-        return {
-            str(row[0])
-            for row in rows
-            if isinstance(row, list) and row
-        }
     except (AttributeError, IndexError, TypeError):
         return None
+    if not isinstance(rows, list):
+        return None
+
+    states: dict[str, bool] = {}
+    for row in rows:
+        if not isinstance(row, list) or len(row) < 6 or not row[0]:
+            continue
+        enabled = row[5]
+        if not isinstance(enabled, bool):
+            continue
+        states[str(row[0])] = enabled
+    return states
+
+
+def query_fcitx_addon_states() -> dict[str, bool] | None:
+    payload = _busctl_json_call(
+        [
+            FCITX_SERVICE,
+            FCITX_CONTROLLER_PATH,
+            FCITX_CONTROLLER_INTERFACE,
+            "GetAddons",
+        ]
+    )
+    return parse_fcitx_addon_states(payload)
+
+
+def query_fcitx_addon_names() -> set[str] | None:
+    """Return enabled addon names from the current Fcitx instance."""
+
+    states = query_fcitx_addon_states()
+    if states is None:
+        return None
+    return {name for name, enabled in states.items() if enabled}
+
+
+def set_fcitx_addon_enabled(unique_name: str, enabled: bool = True) -> bool:
+    """Persist one addon state through the Fcitx controller D-Bus API."""
+
+    busctl = shutil.which("busctl")
+    environment = session_environment()
+    if busctl is None or not environment.get("DBUS_SESSION_BUS_ADDRESS"):
+        return False
+    try:
+        result = subprocess.run(
+            [
+                busctl,
+                "--user",
+                "call",
+                FCITX_SERVICE,
+                FCITX_CONTROLLER_PATH,
+                FCITX_CONTROLLER_INTERFACE,
+                "SetAddonsState",
+                "a(sb)",
+                "1",
+                unique_name,
+                "true" if enabled else "false",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+            env=environment,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return result.returncode == 0
+
+
+_SECTION_RE = re.compile(r"^\s*\[([^\]]+)]\s*$")
+_ITEM_SECTION_RE = re.compile(r"^Groups/([^/]+)/Items/\d+$")
+_GROUP_SECTION_RE = re.compile(r"^Groups/([^/]+)$")
+
+
+def _profile_blocks(text: str) -> list[tuple[str | None, list[str]]]:
+    blocks: list[tuple[str | None, list[str]]] = []
+    section: str | None = None
+    lines: list[str] = []
+    for line in text.splitlines(keepends=True):
+        match = _SECTION_RE.match(line.rstrip("\r\n"))
+        if match:
+            if lines:
+                blocks.append((section, lines))
+            section = match.group(1)
+            lines = [line]
+        else:
+            lines.append(line)
+    if lines:
+        blocks.append((section, lines))
+    return blocks
+
+
+def _profile_value(lines: list[str], key: str) -> str | None:
+    for line in lines[1:]:
+        stripped = line.strip()
+        if not stripped or stripped.startswith(("#", ";")) or "=" not in line:
+            continue
+        name, value = line.split("=", 1)
+        if name.strip() == key:
+            return value.strip()
+    return None
+
+
+def _replace_profile_value(lines: list[str], key: str, value: str) -> list[str]:
+    result = list(lines)
+    pattern = re.compile(rf"^(\s*{re.escape(key)}\s*=\s*).*(\r?\n)?$")
+    for index, line in enumerate(result[1:], start=1):
+        match = pattern.match(line)
+        if match:
+            newline = match.group(2) or ""
+            result[index] = f"{match.group(1)}{value}{newline}"
+            break
+    return result
+
+
+def legacy_fcitx_profile_references(profile: Path | None = None) -> tuple[str, ...]:
+    path = profile or Path.home() / ".config/fcitx5/profile"
+    try:
+        blocks = _profile_blocks(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, OSError, UnicodeError):
+        return ()
+
+    references: list[str] = []
+    for section, lines in blocks:
+        if section is None:
+            continue
+        item_match = _ITEM_SECTION_RE.match(section)
+        if item_match and _profile_value(lines, "Name") == LEGACY_INPUT_METHOD:
+            references.append(section)
+            continue
+        group_match = _GROUP_SECTION_RE.match(section)
+        if group_match and _profile_value(lines, "DefaultIM") == LEGACY_INPUT_METHOD:
+            references.append(f"{section}:DefaultIM")
+    return tuple(references)
+
+
+def migrate_legacy_fcitx_profile(
+    profile: Path | None = None,
+) -> FcitxProfileMigrationResult:
+    """Remove the obsolete standalone VoCoType IM while preserving user IMs.
+
+    VoCoType is now a global Fcitx module. Older installations may still have
+    ``vocotype`` selected in ``~/.config/fcitx5/profile``. Removing only its
+    metadata leaves Fcitx pointing at a non-existent input method, which can
+    replace the user's Rime UI with a fallback state. This migration removes
+    those stale items and restores each affected group to Rime when available.
+    """
+
+    path = profile or Path.home() / ".config/fcitx5/profile"
+    try:
+        original = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return FcitxProfileMigrationResult(False, path)
+    except (OSError, UnicodeError):
+        raise
+
+    blocks = _profile_blocks(original)
+    removed_entries = 0
+    retained: list[tuple[str | None, list[str]]] = []
+    group_items: dict[str, list[str]] = {}
+
+    for section, lines in blocks:
+        item_match = _ITEM_SECTION_RE.match(section or "")
+        if item_match:
+            group = item_match.group(1)
+            name = _profile_value(lines, "Name")
+            if name == LEGACY_INPUT_METHOD:
+                removed_entries += 1
+                continue
+            if name:
+                group_items.setdefault(group, []).append(name)
+        retained.append((section, lines))
+
+    restored_defaults: list[tuple[str, str]] = []
+    groups_needing_item: set[str] = set()
+    rewritten: list[tuple[str | None, list[str]]] = []
+    item_indexes: dict[str, int] = {}
+
+    for section, lines in retained:
+        group_match = _GROUP_SECTION_RE.match(section or "")
+        if group_match and _profile_value(lines, "DefaultIM") == LEGACY_INPUT_METHOD:
+            group = group_match.group(1)
+            items = group_items.get(group, [])
+            fallback = (
+                "rime"
+                if "rime" in items
+                else next(
+                    (name for name in items if not name.startswith("keyboard-")),
+                    items[0] if items else "keyboard-us",
+                )
+            )
+            lines = _replace_profile_value(lines, "DefaultIM", fallback)
+            restored_defaults.append((group, fallback))
+            if not items:
+                groups_needing_item.add(group)
+
+        item_match = _ITEM_SECTION_RE.match(section or "")
+        if item_match:
+            group = item_match.group(1)
+            index = item_indexes.get(group, 0)
+            item_indexes[group] = index + 1
+            newline = "\n"
+            if lines and lines[0].endswith("\r\n"):
+                newline = "\r\n"
+            lines = list(lines)
+            lines[0] = f"[Groups/{group}/Items/{index}]{newline}"
+            section = f"Groups/{group}/Items/{index}"
+
+        rewritten.append((section, lines))
+        if group_match and group_match.group(1) in groups_needing_item:
+            group = group_match.group(1)
+            newline = "\r\n" if lines and lines[0].endswith("\r\n") else "\n"
+            rewritten.append(
+                (
+                    f"Groups/{group}/Items/0",
+                    [
+                        newline,
+                        f"[Groups/{group}/Items/0]{newline}",
+                        f"# Name{newline}",
+                        f"Name=keyboard-us{newline}",
+                        f"# Layout{newline}",
+                        f"Layout={newline}",
+                    ],
+                )
+            )
+            group_items[group] = ["keyboard-us"]
+            item_indexes[group] = 1
+            groups_needing_item.remove(group)
+
+    changed = removed_entries > 0 or bool(restored_defaults)
+    if not changed:
+        return FcitxProfileMigrationResult(False, path)
+
+    migrated = "".join("".join(lines) for _section, lines in rewritten)
+    backup = path.with_name(f"{path.name}.vocotype-backup")
+    if not backup.exists():
+        shutil.copy2(path, backup)
+
+    temporary = path.with_name(f".{path.name}.vocotype-tmp-{os.getpid()}")
+    temporary.write_text(migrated, encoding="utf-8")
+    temporary.chmod(path.stat().st_mode)
+    os.replace(temporary, path)
+    return FcitxProfileMigrationResult(
+        True,
+        path,
+        backup,
+        removed_entries,
+        tuple(restored_defaults),
+    )
+
+
+def _spawn_fcitx(executable: str) -> subprocess.Popen[bytes]:
+    return subprocess.Popen(
+        [executable, "-r", "-d"],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        env=session_environment(),
+        start_new_session=True,
+        close_fds=True,
+    )
 
 
 def restart_fcitx_session(
@@ -107,7 +375,7 @@ def restart_fcitx_session(
     required_addon: str | None = None,
     poll_interval: float = 0.1,
 ) -> FcitxRestartResult:
-    """Replace Fcitx without waiting for the persistent daemon to exit."""
+    """Replace Fcitx, enabling the required addon when it was disabled."""
 
     executable = shutil.which("fcitx5")
     if executable is None:
@@ -115,35 +383,54 @@ def restart_fcitx_session(
 
     previous_owner = query_fcitx_bus_owner()
     try:
-        process = subprocess.Popen(
-            [executable, "-r", "-d"],
-            stdin=subprocess.DEVNULL,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            env=session_environment(),
-            start_new_session=True,
-            close_fds=True,
-        )
+        process = _spawn_fcitx(executable)
     except OSError as exc:
         return FcitxRestartResult(False, f"无法启动 Fcitx 5：{exc}")
 
     deadline = time.monotonic() + max(0.5, timeout)
     latest_owner: str | None = None
-    latest_addons: set[str] | None = None
+    latest_states: dict[str, bool] | None = None
+    enable_attempted = False
     while time.monotonic() < deadline:
         latest_owner = query_fcitx_bus_owner()
-        latest_addons = query_fcitx_addon_names()
+        latest_states = query_fcitx_addon_states()
         owner_replaced = latest_owner is not None and (
             previous_owner is None or latest_owner != previous_owner
         )
         addon_ready = required_addon is None or (
-            latest_addons is not None and required_addon in latest_addons
+            latest_states is not None and latest_states.get(required_addon) is True
         )
         if owner_replaced and addon_ready:
             message = "Fcitx 5 已重新启动"
             if required_addon:
-                message += f"，并已加载 {required_addon} addon"
+                message += f"，并已启用 {required_addon} addon"
             return FcitxRestartResult(True, message, owner=latest_owner)
+
+        addon_disabled = (
+            owner_replaced
+            and required_addon is not None
+            and latest_states is not None
+            and latest_states.get(required_addon) is False
+        )
+        if addon_disabled and not enable_attempted:
+            enable_attempted = True
+            if not set_fcitx_addon_enabled(required_addon, True):
+                return FcitxRestartResult(
+                    False,
+                    f"已发现 addon={required_addon}，但自动启用失败",
+                    owner=latest_owner,
+                )
+            previous_owner = latest_owner
+            try:
+                process = _spawn_fcitx(executable)
+            except OSError as exc:
+                return FcitxRestartResult(
+                    False,
+                    f"已启用 addon={required_addon}，但无法再次启动 Fcitx 5：{exc}",
+                    owner=latest_owner,
+                )
+            time.sleep(max(0.01, poll_interval))
+            continue
 
         return_code = process.poll()
         if return_code not in (None, 0):
@@ -154,17 +441,23 @@ def restart_fcitx_session(
             )
         time.sleep(max(0.01, poll_interval))
 
-    addon_text = (
+    enabled_text = (
         "无法查询"
-        if latest_addons is None
-        else ", ".join(sorted(latest_addons)) or "空"
+        if latest_states is None
+        else ", ".join(
+            sorted(name for name, enabled in latest_states.items() if enabled)
+        )
+        or "空"
     )
-    required_text = (
-        f"；未加载所需 addon={required_addon}" if required_addon else ""
-    )
+    if required_addon and latest_states is not None and required_addon in latest_states:
+        required_text = f"；addon={required_addon} 已发现但仍未启用"
+    else:
+        required_text = (
+            f"；未发现所需 addon={required_addon}" if required_addon else ""
+        )
     return FcitxRestartResult(
         False,
         "等待新 Fcitx 5 实例就绪超时；"
-        f"owner={latest_owner or '无'}，addons={addon_text}{required_text}",
+        f"owner={latest_owner or '无'}，enabled_addons={enabled_text}{required_text}",
         owner=latest_owner,
     )

--- a/fcitx5/scripts/install.sh
+++ b/fcitx5/scripts/install.sh
@@ -926,6 +926,15 @@ if ! systemctl --user enable --now vocotype-fcitx5-backend.service; then
 fi
 echo "✓ 后台服务已启用并启动"
 
+echo ""
+emit_install_progress 92 "迁移旧版 Fcitx 输入法配置"
+echo "检查旧版独立 VoCoType 输入法残留..."
+if ! PYTHONPATH="$INSTALL_DIR${PYTHONPATH:+:$PYTHONPATH}" \
+    "$PYTHON" "$PROJECT_DIR/installers/migrate-fcitx-profile.py"; then
+    echo "错误: 无法安全迁移旧版 Fcitx profile，安装已停止。" >&2
+    exit 1
+fi
+
 if [ "$PYTHON" = "$PROJECT_DIR/.venv/bin/python" ]; then
     echo "⚠️  当前选择的是项目虚拟环境。若重命名或删除仓库目录，需要重新安装或改用用户级环境。"
 fi

--- a/installers/migrate-fcitx-profile.py
+++ b/installers/migrate-fcitx-profile.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Migrate stale standalone VoCoType entries from the Fcitx profile."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app.fcitx_session import migrate_legacy_fcitx_profile  # noqa: E402
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--profile", type=Path)
+    args = parser.parse_args()
+    try:
+        result = migrate_legacy_fcitx_profile(args.profile)
+    except Exception as exc:  # noqa: BLE001 - installer must report concise failure.
+        print(f"❌ 无法迁移旧版 Fcitx profile：{exc}", flush=True)
+        return 1
+
+    if not result.changed:
+        print("✓ Fcitx profile 无旧版 VoCoType 输入法残留", flush=True)
+        return 0
+
+    defaults = ", ".join(
+        f"group {group} → {fallback}"
+        for group, fallback in result.restored_defaults
+    )
+    detail = f"；恢复默认输入法：{defaults}" if defaults else ""
+    print(
+        f"✓ 已从 Fcitx profile 移除 {result.removed_entries} 个旧版 VoCoType 条目"
+        f"{detail}",
+        flush=True,
+    )
+    if result.backup:
+        print(f"  原 profile 已备份到：{result.backup}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/settings_center/doctor.py
+++ b/settings_center/doctor.py
@@ -22,6 +22,10 @@ from .config_service import (
     terms_path,
 )
 from app.download_models import inspect_required_models
+from app.fcitx_session import (
+    legacy_fcitx_profile_references,
+    parse_fcitx_addon_states,
+)
 from .setup_manager import installation_paths
 
 
@@ -297,34 +301,39 @@ def run_doctor(*, include_slm_probe: bool = False) -> list[DoctorCheck]:
             )
         try:
             payload = json.loads(result.stdout)
-            rows = payload.get("data", [[]])[0]
-            loaded_names = {
-                str(row[0])
-                for row in rows
-                if isinstance(row, list) and row
-            }
-        except (json.JSONDecodeError, AttributeError, IndexError, TypeError) as exc:
+            addon_states = parse_fcitx_addon_states(payload)
+            if addon_states is None:
+                raise ValueError("GetAddons 返回结构不完整")
+        except (json.JSONDecodeError, TypeError, ValueError) as exc:
             return _fail(
                 "fcitx_loaded",
                 "Fcitx addon 加载",
                 "无法解析 Fcitx GetAddons 响应",
                 f"{exc}: {result.stdout[:2000]}",
             )
-        if "vocotype" in loaded_names:
+        if addon_states.get("vocotype") is True:
             return _pass(
                 "fcitx_loaded",
                 "Fcitx addon 加载",
-                "当前 Fcitx 实例已实际创建 VoCoType 全局 addon",
+                "当前 Fcitx 实例已启用 VoCoType 全局 addon",
             )
         installed = "\n".join(
             str(path)
             for path in [*paths.fcitx_modules, *paths.fcitx_addons]
             if path.is_file()
         )
+        if "vocotype" in addon_states:
+            return _fail(
+                "fcitx_loaded",
+                "Fcitx addon 加载",
+                "VoCoType addon 已被发现，但当前处于禁用状态",
+                installed,
+                "重新运行安装 / 修复；安装器会自动启用 addon 并重启 Fcitx 5。",
+            )
         return _fail(
             "fcitx_loaded",
             "Fcitx addon 加载",
-            "文件存在，但当前 Fcitx 实例没有创建 VoCoType addon",
+            "文件存在，但当前 Fcitx 实例没有发现 VoCoType addon",
             installed,
             "重新运行安装 / 修复并完成 Polkit 更新；然后重启 Fcitx 5。",
         )
@@ -357,16 +366,25 @@ def run_doctor(*, include_slm_probe: bool = False) -> list[DoctorCheck]:
 
     def legacy_check() -> DoctorCheck:
         legacy = Path.home() / ".local/share/fcitx5/inputmethod/vocotype.conf"
+        profile = Path.home() / ".config/fcitx5/profile"
+        profile_references = legacy_fcitx_profile_references(profile)
         if ibus_vocotype_installed and not fcitx_vocotype_installed:
             return _info("legacy_entry", "旧版输入法条目", "IBus-only 环境无需检查")
-        if not legacy.exists():
+        if not legacy.exists() and not profile_references:
             return _pass("legacy_entry", "旧版输入法条目", "未发现旧版独立输入法条目")
+        details = []
+        if legacy.exists():
+            details.append(str(legacy))
+        if profile_references:
+            details.append(
+                f"{profile}: " + ", ".join(profile_references)
+            )
         return _warn(
             "legacy_entry",
             "旧版输入法条目",
-            "仍存在旧版 VoCoType 输入法描述",
-            str(legacy),
-            f"删除 {legacy} 后重启 Fcitx。",
+            "Fcitx 仍引用已经废弃的独立 VoCoType 输入法",
+            "\n".join(details),
+            "重新运行安装 / 修复；安装器会备份 profile、恢复 Rime 并清理旧条目。",
         )
 
     checks.append(_check("legacy_entry", "旧版输入法条目", legacy_check))

--- a/tests/test_fcitx_module.py
+++ b/tests/test_fcitx_module.py
@@ -42,6 +42,7 @@ def test_installer_builds_module_and_removes_legacy_input_method():
     ).read_text(encoding="utf-8")
     assert '"$PROJECT_DIR/fcitx5/module/build"' in installer
     assert 'rm -f "$HOME/.local/share/fcitx5/inputmethod/vocotype.conf"' in installer
+    assert 'installers/migrate-fcitx-profile.py' in installer
     assert "uv pip install pyrime" not in installer
     assert '"$PYTHON" -m pip install pyrime' not in installer
 

--- a/tests/test_fcitx_session.py
+++ b/tests/test_fcitx_session.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import subprocess
+from pathlib import Path
 
 import pytest
 
@@ -13,11 +14,64 @@ def test_session_environment_removes_legacy_addon_override(monkeypatch: pytest.M
     assert "FCITX_ADDON_DIRS" not in environment
 
 
+def test_parse_fcitx_addon_states_distinguishes_discovered_from_enabled():
+    payload = {
+        "type": "a(sssibb)",
+        "data": [
+            [
+                ["vocotype", "VoCoType", "", 3, True, False],
+                ["rime", "Rime", "", 2, True, True],
+            ]
+        ],
+    }
+    assert fcitx_session.parse_fcitx_addon_states(payload) == {
+        "vocotype": False,
+        "rime": True,
+    }
+    assert fcitx_session.parse_fcitx_addon_states({"data": [[]]}) == {}
+    assert fcitx_session.parse_fcitx_addon_states({"data": "broken"}) is None
+
+
+def test_set_fcitx_addon_enabled_uses_controller_state_signature(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    calls: list[tuple[list[str], dict[str, object]]] = []
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs))
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    monkeypatch.setattr(fcitx_session.shutil, "which", lambda _name: "/usr/bin/busctl")
+    monkeypatch.setattr(
+        fcitx_session,
+        "session_environment",
+        lambda _base=None: {"DBUS_SESSION_BUS_ADDRESS": "unix:path=/run/user/1000/bus"},
+    )
+    monkeypatch.setattr(fcitx_session.subprocess, "run", fake_run)
+
+    assert fcitx_session.set_fcitx_addon_enabled("vocotype", True)
+    command, kwargs = calls[0]
+    assert command == [
+        "/usr/bin/busctl",
+        "--user",
+        "call",
+        "org.fcitx.Fcitx5",
+        "/controller",
+        "org.fcitx.Fcitx.Controller1",
+        "SetAddonsState",
+        "a(sb)",
+        "1",
+        "vocotype",
+        "true",
+    ]
+    assert kwargs["env"]["DBUS_SESSION_BUS_ADDRESS"].endswith("/bus")
+
+
 def test_restart_fcitx_session_does_not_pipe_or_wait_for_persistent_daemon(
     monkeypatch: pytest.MonkeyPatch,
 ):
     owners = iter([":1.10", ":1.10", ":1.11"])
-    addons = iter([set(), {"vocotype"}])
+    addon_states = iter([{}, {"vocotype": True}])
     popen_calls: list[tuple[list[str], dict[str, object]]] = []
 
     class FakeProcess:
@@ -30,7 +84,11 @@ def test_restart_fcitx_session_does_not_pipe_or_wait_for_persistent_daemon(
 
     monkeypatch.setattr(fcitx_session.shutil, "which", lambda name: f"/usr/bin/{name}")
     monkeypatch.setattr(fcitx_session, "query_fcitx_bus_owner", lambda: next(owners))
-    monkeypatch.setattr(fcitx_session, "query_fcitx_addon_names", lambda: next(addons))
+    monkeypatch.setattr(
+        fcitx_session,
+        "query_fcitx_addon_states",
+        lambda: next(addon_states),
+    )
     monkeypatch.setattr(fcitx_session.subprocess, "Popen", fake_popen)
     monkeypatch.setattr(fcitx_session.time, "sleep", lambda _seconds: None)
 
@@ -52,6 +110,50 @@ def test_restart_fcitx_session_does_not_pipe_or_wait_for_persistent_daemon(
     assert "FCITX_ADDON_DIRS" not in kwargs["env"]
 
 
+def test_restart_fcitx_session_enables_disabled_required_addon(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    owners = iter([":1.10", ":1.11", ":1.12"])
+    addon_states = iter([{"vocotype": False}, {"vocotype": True}])
+    enable_calls: list[tuple[str, bool]] = []
+    popen_calls = 0
+
+    class FakeProcess:
+        def poll(self):
+            return None
+
+    def fake_popen(*_args, **_kwargs):
+        nonlocal popen_calls
+        popen_calls += 1
+        return FakeProcess()
+
+    monkeypatch.setattr(fcitx_session.shutil, "which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr(fcitx_session, "query_fcitx_bus_owner", lambda: next(owners))
+    monkeypatch.setattr(
+        fcitx_session,
+        "query_fcitx_addon_states",
+        lambda: next(addon_states),
+    )
+    monkeypatch.setattr(
+        fcitx_session,
+        "set_fcitx_addon_enabled",
+        lambda name, enabled=True: enable_calls.append((name, enabled)) or True,
+    )
+    monkeypatch.setattr(fcitx_session.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(fcitx_session.time, "sleep", lambda _seconds: None)
+
+    result = fcitx_session.restart_fcitx_session(
+        timeout=1.0,
+        required_addon="vocotype",
+        poll_interval=0.01,
+    )
+
+    assert result.success, result.message
+    assert result.owner == ":1.12"
+    assert enable_calls == [("vocotype", True)]
+    assert popen_calls == 2
+
+
 def test_restart_fcitx_session_reports_missing_required_addon(
     monkeypatch: pytest.MonkeyPatch,
 ):
@@ -62,7 +164,11 @@ def test_restart_fcitx_session_reports_missing_required_addon(
     owners = iter([":1.10", ":1.11", ":1.11", ":1.11"])
     monkeypatch.setattr(fcitx_session.shutil, "which", lambda name: f"/usr/bin/{name}")
     monkeypatch.setattr(fcitx_session, "query_fcitx_bus_owner", lambda: next(owners, ":1.11"))
-    monkeypatch.setattr(fcitx_session, "query_fcitx_addon_names", lambda: {"keyboard"})
+    monkeypatch.setattr(
+        fcitx_session,
+        "query_fcitx_addon_states",
+        lambda: {"keyboard": True},
+    )
     monkeypatch.setattr(fcitx_session.subprocess, "Popen", lambda *_args, **_kwargs: FakeProcess())
 
     now = iter([0.0, 0.0, 1.0])
@@ -74,5 +180,65 @@ def test_restart_fcitx_session_reports_missing_required_addon(
         required_addon="vocotype",
     )
     assert not result.success
-    assert "未加载所需 addon=vocotype" in result.message
+    assert "未发现所需 addon=vocotype" in result.message
     assert "keyboard" in result.message
+
+
+def test_migrate_legacy_fcitx_profile_restores_rime_and_keeps_backup(
+    tmp_path: Path,
+):
+    profile = tmp_path / "profile"
+    original = """[Groups/0]
+# Group Name
+Name=默认
+# Default Input Method
+DefaultIM=vocotype
+
+[Groups/0/Items/0]
+# Name
+Name=keyboard-us
+# Layout
+Layout=
+
+[Groups/0/Items/1]
+# Name
+Name=vocotype
+# Layout
+Layout=
+
+[Groups/0/Items/2]
+# Name
+Name=rime
+# Layout
+Layout=
+
+[GroupOrder]
+0=默认
+"""
+    profile.write_text(original, encoding="utf-8")
+
+    references = fcitx_session.legacy_fcitx_profile_references(profile)
+    assert references == ("Groups/0:DefaultIM", "Groups/0/Items/1")
+
+    result = fcitx_session.migrate_legacy_fcitx_profile(profile)
+
+    assert result.changed
+    assert result.removed_entries == 1
+    assert result.restored_defaults == (("0", "rime"),)
+    assert result.backup == tmp_path / "profile.vocotype-backup"
+    assert result.backup.read_text(encoding="utf-8") == original
+
+    migrated = profile.read_text(encoding="utf-8")
+    assert "DefaultIM=rime" in migrated
+    assert "Name=vocotype" not in migrated
+    assert "[Groups/0/Items/0]" in migrated
+    assert "Name=keyboard-us" in migrated
+    assert "[Groups/0/Items/1]" in migrated
+    assert "Name=rime" in migrated
+    assert "[Groups/0/Items/2]" not in migrated
+    assert "[GroupOrder]" in migrated
+    assert fcitx_session.legacy_fcitx_profile_references(profile) == ()
+
+    second = fcitx_session.migrate_legacy_fcitx_profile(profile)
+    assert not second.changed
+    assert result.backup.read_text(encoding="utf-8") == original

--- a/tests/test_release_packaging.py
+++ b/tests/test_release_packaging.py
@@ -61,6 +61,7 @@ def test_repository_layout_groups_tools_by_responsibility():
         "installers/uninstall-integration.sh",
         "fcitx5/scripts/install.sh",
         "installers/check-python-runtime.py",
+        "installers/migrate-fcitx-profile.py",
         "packaging/tools/build-release.py",
         "packaging/tests/smoke-installed-package.sh",
         "packaging/tests/smoke-ibus-registry.sh",

--- a/tests/test_settings_center.py
+++ b/tests/test_settings_center.py
@@ -1030,10 +1030,11 @@ def test_setup_manager_does_not_launch_terminal_emulators():
 
 
 @pytest.mark.parametrize(
-    ("addon_rows", "expected_status"),
+    ("addon_rows", "expected_status", "expected_summary"),
     [
-        ([['vocotype', 'VoCoType Voice Input', '', 3, True, True]], 'pass'),
-        ([['clipboard', 'Clipboard', '', 3, True, True]], 'fail'),
+        ([['vocotype', 'VoCoType Voice Input', '', 3, True, True]], 'pass', '已启用'),
+        ([['vocotype', 'VoCoType Voice Input', '', 3, True, False]], 'fail', '禁用状态'),
+        ([['clipboard', 'Clipboard', '', 3, True, True]], 'fail', '没有发现'),
     ],
 )
 def test_doctor_uses_live_fcitx_getaddons_for_loaded_state(
@@ -1041,6 +1042,7 @@ def test_doctor_uses_live_fcitx_getaddons_for_loaded_state(
     tmp_path: Path,
     addon_rows: list[list[object]],
     expected_status: str,
+    expected_summary: str,
 ):
     import settings_center.doctor as doctor_module
 
@@ -1088,8 +1090,7 @@ def test_doctor_uses_live_fcitx_getaddons_for_loaded_state(
     monkeypatch.setattr(doctor_module, '_run', fake_run)
     check = next(item for item in run_doctor() if item.check_id == 'fcitx_loaded')
     assert check.status == expected_status
-    if expected_status == 'fail':
-        assert '没有创建 VoCoType addon' in check.summary
+    assert expected_summary in check.summary
 
 
 def test_doctor_reports_polkit_readiness(monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
Closed because the historical Python patch cannot be safely replayed over the current V3 branch through GitHub's conflict-free API. The fix must be rebased in the local repository, and Beta4 requires a native C++ port rather than this Python commit. Do not merge this PR.