### PR TITLE
fix: 修复设置中心启动器项目根目录解析

### DIFF
--- a/scripts/install/common/install-native-user.sh
+++ b/scripts/install/common/install-native-user.sh
@@ -322,9 +322,21 @@ done
 echo "VoCoType native audio recorder is not installed" >&2
 exit 78
 LAUNCH
-  cat > "$USER_BIN/vocotype-settings" <<'LAUNCH'
-#!/usr/bin/env bash
-set -euo pipefail
+  # The settings center resolves scripts/install/common/*.sh relative to its
+  # project root. Desktop launchers start it with the home directory as the
+  # working directory, not the tree used for install, so record that tree here.
+  # printf %q keeps arbitrary characters in the path safe inside the launcher.
+  {
+    printf '%s\n' '#!/usr/bin/env bash' 'set -euo pipefail'
+    printf 'recorded_project_dir=%q\n' "$PROJECT_DIR"
+    cat <<'LAUNCH'
+# Respect a caller-provided root, and only fall back to the recorded tree while
+# it still holds the installer. A stale path must not shadow the system package.
+if [[ -z "${VOCOTYPE_PROJECT_DIR:-}" &&
+      -f "$recorded_project_dir/scripts/install/common/install-native-user.sh" ]]; then
+  export VOCOTYPE_PROJECT_DIR="$recorded_project_dir"
+fi
+unset recorded_project_dir
 for settings in "$HOME/.local/lib/vocotype-native/bin/vocotype-settings" /usr/bin/vocotype-settings; do
   [[ -x "$settings" ]] || continue
   [[ "$settings" == "$0" ]] && continue
@@ -333,6 +345,7 @@ done
 echo "VoCoType native settings center is not installed" >&2
 exit 78
 LAUNCH
+  } > "$USER_BIN/vocotype-settings"
   chmod 0755 "$USER_BIN/vocotype-fcitx5-backend" \
     "$USER_BIN/vocotype-fcitx5-recorder" "$USER_BIN/vocotype-settings"
 }


### PR DESCRIPTION
## 问题
桌面启动器以用户主目录作为工作目录启动 `vocotype-settings`，导致设置中心将 `$HOME` 误判为项目根目录，无法找到安装和卸载脚本。

## 修复
- 生成 `vocotype-settings` 启动器时记录安装时的项目根目录。
- 仅在调用方未显式设置 `VOCOTYPE_PROJECT_DIR` 且记录路径仍有效时导出该变量。
- 使用 `printf %q` 安全处理包含空格或特殊字符的路径。
- 避免陈旧源码路径遮蔽系统包。

## 验证
- `bash -n scripts/install/common/install-native-user.sh`
- `git diff master --check`

独立提交：`c88e8cb`