### PR TITLE
fix: align Fcitx5 transcription timeout with Core

### DIFF
--- a/src/integrations/fcitx5/common/ipc_client.cpp
+++ b/src/integrations/fcitx5/common/ipc_client.cpp
@@ -133,7 +133,7 @@ TranscribeResult IPCClient::transcribeAudio(const std::string& audio_path, bool 
         };
 
         // 发送请求
-        std::string response_str = sendRequest(request.dump());
+        std::string response_str = sendRequest(request.dump(), 15000);
 
         // 解析响应
         json response = json::parse(response_str);


### PR DESCRIPTION
Fixes #47

## Problem
Fcitx5 voice transcription could show `Failed to receive response` after recording when final recognition took longer than two seconds.

## Cause
`IPCClient::transcribeAudio()` omitted the receive timeout argument and therefore used the default 2000 ms timeout. Core offline ASR and the other frontends allow longer-running recognition requests.

## Fix
Pass a **15000 ms** receive timeout for the final Fcitx5 transcription request. This removes the overly aggressive 2-second client timeout while keeping the user-facing wait bounded, instead of making Fcitx5 wait indefinitely for a stuck backend.

This is intentionally a frontend timeout only; it does not change the Core ASR execution budget.

## Validation
- `git diff --check`
- Dedicated worktree contains only `src/integrations/fcitx5/common/ipc_client.cpp`.
- Commit: `1c5419d`