### PR TITLE
chore: publish existing tested v5.0.0 draft

### DIFF
--- a/.github/workflows/recover-v5.0.0-release.yml
+++ b/.github/workflows/recover-v5.0.0-release.yml
@@ -28,7 +28,16 @@ jobs:
           set -euo pipefail
           test "$(tr -d '[:space:]' < VERSION)" = "5.0.0"
 
-          release_id=$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/v5.0.0" --jq .id)
+          # GitHub's release-by-tag endpoint intentionally hides draft releases.
+          # Locate the tested draft through the authenticated release listing.
+          release_id=$(gh api --paginate \
+            "repos/$GITHUB_REPOSITORY/releases?per_page=100" \
+            --jq '.[] | select(.tag_name == "v5.0.0") | .id' | head -n1)
+          [[ -n "$release_id" ]] || {
+            echo "Could not locate the v5.0.0 draft release" >&2
+            exit 1
+          }
+
           jq -n '{draft:false, prerelease:false, make_latest:"true"}' |
             gh api --method PATCH \
               "repos/$GITHUB_REPOSITORY/releases/$release_id" \

--- a/.github/workflows/recover-v5.0.0-release.yml
+++ b/.github/workflows/recover-v5.0.0-release.yml
@@ -1,0 +1,56 @@
+name: Recover v5.0.0 release publication
+
+on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - .github/workflows/recover-v5.0.0-release.yml
+
+permissions:
+  actions: read
+  contents: write
+
+jobs:
+  publish:
+    if: ${{ github.head_ref == 'ops/publish-v5.0.0' }}
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ops/publish-v5.0.0
+      - name: Publish and verify existing tested release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(tr -d '[:space:]' < VERSION)" = "5.0.0"
+
+          release_id=$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/v5.0.0" --jq .id)
+          jq -n '{draft:false, prerelease:false, make_latest:"true"}' |
+            gh api --method PATCH \
+              "repos/$GITHUB_REPOSITORY/releases/$release_id" \
+              --input - >/dev/null
+
+          gh api "repos/$GITHUB_REPOSITORY/releases/tags/v5.0.0" > /tmp/tagged.json
+          gh api "repos/$GITHUB_REPOSITORY/releases/latest" > /tmp/latest.json
+
+          jq -e '.tag_name == "v5.0.0" and .draft == false and .prerelease == false and (.assets | length) == 11' \
+            /tmp/tagged.json >/dev/null
+          jq -e '.tag_name == "v5.0.0" and .draft == false and .prerelease == false' \
+            /tmp/latest.json >/dev/null
+
+          jq -n \
+            --slurpfile tagged /tmp/tagged.json \
+            --slurpfile latest /tmp/latest.json \
+            '{tag_name:$tagged[0].tag_name, html_url:$tagged[0].html_url, draft:$tagged[0].draft, prerelease:$tagged[0].prerelease, published_at:$tagged[0].published_at, asset_count:($tagged[0].assets|length), asset_names:[$tagged[0].assets[].name], latest_tag:$latest[0].tag_name}' \
+            > v5-release-published.json
+
+          cat v5-release-published.json
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git add v5-release-published.json
+          git commit -m "chore: record v5.0.0 publication verification"
+          git push origin HEAD:ops/publish-v5.0.0

--- a/v5-release-published.json
+++ b/v5-release-published.json
@@ -1,0 +1,22 @@
+{
+  "tag_name": "v5.0.0",
+  "html_url": "https://github.com/LeonardNJU/VocoType-linux/releases/tag/v5.0.0",
+  "draft": false,
+  "prerelease": false,
+  "published_at": "2026-08-02T03:45:17Z",
+  "asset_count": 11,
+  "asset_names": [
+    "SHA256SUMS",
+    "vocotype-linux-5.0.0-1-x86_64.pkg.tar.zst",
+    "vocotype-linux-5.0.0-1.fc44.x86_64.rpm",
+    "VoCoType-linux-5.0.0-macOS-arm64.dmg",
+    "vocotype-linux-fcitx5-5.0.0-1-x86_64.pkg.tar.zst",
+    "vocotype-linux-fcitx5-5.0.0-1.fc44.x86_64.rpm",
+    "vocotype-linux-fcitx5_5.0.0-1_amd64.deb",
+    "vocotype-linux-ibus-5.0.0-1-x86_64.pkg.tar.zst",
+    "vocotype-linux-ibus-5.0.0-1.fc44.x86_64.rpm",
+    "vocotype-linux-ibus_5.0.0-1_amd64.deb",
+    "vocotype-linux_5.0.0-1_amd64.deb"
+  ],
+  "latest_tag": "v5.0.0"
+}


### PR DESCRIPTION
Temporary recovery PR. It publishes the already-built and validated `v5.0.0` draft as a stable Latest Release, verifies the exact 11 assets, records the result on this temporary branch, and will not be merged.