### PR TITLE
Fix #54 native core cold-start failure propagation

### DIFF
--- a/src/desktop/CMakeLists.txt
+++ b/src/desktop/CMakeLists.txt
@@ -135,7 +135,6 @@ if(BUILD_TESTING)
   add_test(NAME vocotype-streaming-preview-tests
            COMMAND vocotype-streaming-preview-tests)
 
-
   add_executable(vocotype-ipc-quick-response-tests
     tests/ipc_quick_response_tests.cpp
   )
@@ -144,6 +143,19 @@ if(BUILD_TESTING)
   )
   add_test(NAME vocotype-ipc-quick-response-tests
            COMMAND vocotype-ipc-quick-response-tests)
+
+  add_executable(vocotype-fake-native-core
+    tests/fake_native_core.cpp
+  )
+  add_executable(vocotype-ipc-core-start-tests
+    tests/ipc_core_start_tests.cpp
+  )
+  target_link_libraries(vocotype-ipc-core-start-tests PRIVATE
+    vocotype_desktop_common
+  )
+  add_test(NAME vocotype-ipc-core-cold-start
+           COMMAND vocotype-ipc-core-start-tests
+                   $<TARGET_FILE:vocotype-fake-native-core>)
 
   add_executable(vocotype-fake-slow-preview-recorder
     tests/fake_slow_preview_recorder.cpp

--- a/src/desktop/include/vocotype/desktop/ipc.hpp
+++ b/src/desktop/include/vocotype/desktop/ipc.hpp
@@ -6,6 +6,13 @@
 #include <sys/types.h>
 namespace vocotype::desktop {
 using Json = nlohmann::json;
+
+struct NativeCoreEnsureResult {
+  bool ready = false;
+  std::string error;
+  int exit_code = -1;
+};
+
 Json unix_json_request(const std::string &socket_path, const Json &request,
                        int timeout_ms = 2000);
 std::string base64_encode(const unsigned char *data, std::size_t size);
@@ -17,6 +24,11 @@ bool start_native_core_service(bool restart = false,
                                int wait_ms = 45000);
 pid_t start_native_core(const std::string &socket_path = {},
                         const std::filesystem::path &config_path = {});
+NativeCoreEnsureResult
+ensure_native_core_status(const std::string &socket_path = {},
+                          const std::filesystem::path &config_path = {},
+                          int wait_ms = 45000);
+std::string native_core_last_error(const std::string &socket_path = {});
 bool ensure_native_core(const std::string &socket_path = {},
                         const std::filesystem::path &config_path = {},
                         int wait_ms = 45000);

--- a/src/desktop/src/ipc.cpp
+++ b/src/desktop/src/ipc.cpp
@@ -6,6 +6,7 @@
 #include <chrono>
 #include <cstring>
 #include <filesystem>
+#include <fcntl.h>
 #include <mutex>
 #include <signal.h>
 #include <stdexcept>
@@ -14,10 +15,113 @@
 #include <sys/un.h>
 #include <sys/wait.h>
 #include <thread>
+#include <unordered_map>
 #include <unistd.h>
+
 namespace vocotype::desktop {
-Json unix_json_request(const std::string &socket_path, const Json &request,
-                       int timeout_ms) {
+namespace {
+
+std::mutex native_core_error_mutex;
+std::unordered_map<std::string, std::string> native_core_errors;
+
+std::string resolved_socket_path(const std::string &requested_socket) {
+  return requested_socket.empty() ? backend_socket_path() : requested_socket;
+}
+
+void clear_native_core_error(const std::string &socket) {
+  std::lock_guard lock(native_core_error_mutex);
+  native_core_errors.erase(socket);
+}
+
+void remember_native_core_error(const std::string &socket,
+                                const std::string &error) {
+  std::lock_guard lock(native_core_error_mutex);
+  native_core_errors[socket] = error;
+}
+
+std::string compact_error(std::string value) {
+  std::replace(value.begin(), value.end(), '\r', ' ');
+  std::replace(value.begin(), value.end(), '\n', ' ');
+  while (!value.empty() && value.back() == ' ')
+    value.pop_back();
+  while (!value.empty() && value.front() == ' ')
+    value.erase(value.begin());
+  constexpr std::size_t kMaximum = 2048;
+  if (value.size() > kMaximum)
+    value = value.substr(0, kMaximum) + "…";
+  return value;
+}
+
+std::string read_available(int descriptor) {
+  std::string output;
+  char buffer[1024];
+  for (;;) {
+    const ssize_t count = ::read(descriptor, buffer, sizeof(buffer));
+    if (count > 0) {
+      output.append(buffer, static_cast<std::size_t>(count));
+      continue;
+    }
+    if (count < 0 && errno == EINTR)
+      continue;
+    if (count < 0 && (errno == EAGAIN || errno == EWOULDBLOCK))
+      break;
+    break;
+  }
+  return output;
+}
+
+std::string child_failure_message(int status, const std::string &stderr_text) {
+  std::string message = "native core failed to start";
+  if (WIFEXITED(status))
+    message += " (exit=" + std::to_string(WEXITSTATUS(status)) + ")";
+  else if (WIFSIGNALED(status))
+    message += " (signal=" + std::to_string(WTERMSIG(status)) + ")";
+  const std::string details = compact_error(stderr_text);
+  if (!details.empty())
+    message += ": " + details;
+  return message;
+}
+
+void detach_core_reaper(pid_t child, int stderr_descriptor) {
+  const int flags = ::fcntl(stderr_descriptor, F_GETFL, 0);
+  if (flags >= 0)
+    (void)::fcntl(stderr_descriptor, F_SETFL, flags & ~O_NONBLOCK);
+  std::thread([child, stderr_descriptor] {
+    char buffer[1024];
+    for (;;) {
+      const ssize_t count = ::read(stderr_descriptor, buffer, sizeof(buffer));
+      if (count > 0)
+        continue;
+      if (count < 0 && errno == EINTR)
+        continue;
+      break;
+    }
+    ::close(stderr_descriptor);
+    int status = 0;
+    while (::waitpid(child, &status, 0) < 0 && errno == EINTR) {
+    }
+  }).detach();
+}
+
+int terminate_child(pid_t child) {
+  (void)::kill(child, SIGTERM);
+  int status = 0;
+  for (int attempt = 0; attempt < 20; ++attempt) {
+    const pid_t waited = ::waitpid(child, &status, WNOHANG);
+    if (waited == child)
+      return status;
+    if (waited < 0 && errno != EINTR)
+      return status;
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  }
+  (void)::kill(child, SIGKILL);
+  while (::waitpid(child, &status, 0) < 0 && errno == EINTR) {
+  }
+  return status;
+}
+
+Json unix_json_request_impl(const std::string &socket_path, const Json &request,
+                            int timeout_ms, bool surface_startup_error) {
   const int fd = vocotype::common::create_socket_close_on_exec(
       AF_UNIX, SOCK_STREAM, 0);
   if (fd < 0)
@@ -35,11 +139,18 @@ Json unix_json_request(const std::string &socket_path, const Json &request,
   std::memcpy(address.sun_path, socket_path.c_str(), socket_path.size() + 1);
   if (::connect(fd, reinterpret_cast<sockaddr *>(&address), sizeof(address)) !=
       0) {
-    const auto message =
-        std::string("cannot connect to native core: ") + std::strerror(errno);
+    const int connect_error = errno;
     ::close(fd);
-    throw std::runtime_error(message);
+    if (surface_startup_error &&
+        (connect_error == ENOENT || connect_error == ECONNREFUSED)) {
+      const std::string startup_error = native_core_last_error(socket_path);
+      if (!startup_error.empty())
+        throw std::runtime_error(startup_error);
+    }
+    throw std::runtime_error(std::string("cannot connect to native core: ") +
+                             std::strerror(connect_error));
   }
+  clear_native_core_error(socket_path);
   const std::string payload = request.dump();
   std::size_t offset = 0;
   while (offset < payload.size()) {
@@ -74,6 +185,14 @@ Json unix_json_request(const std::string &socket_path, const Json &request,
   ::close(fd);
   return Json::parse(response);
 }
+
+} // namespace
+
+Json unix_json_request(const std::string &socket_path, const Json &request,
+                       int timeout_ms) {
+  return unix_json_request_impl(socket_path, request, timeout_ms, true);
+}
+
 std::string base64_encode(const unsigned char *data, std::size_t size) {
   static constexpr char table[] =
       "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
@@ -94,10 +213,9 @@ std::string base64_encode(const unsigned char *data, std::size_t size) {
 
 bool native_core_ready(const std::string &requested_socket, int timeout_ms) {
   try {
-    const std::string socket =
-        requested_socket.empty() ? backend_socket_path() : requested_socket;
+    const std::string socket = resolved_socket_path(requested_socket);
     const Json response =
-        unix_json_request(socket, {{"type", "ping"}}, timeout_ms);
+        unix_json_request_impl(socket, {{"type", "ping"}}, timeout_ms, false);
     return response.value("success", false) && response.value("pong", false) &&
            response.value("backend", "") == "cpp";
   } catch (const std::exception &) {
@@ -165,8 +283,7 @@ bool start_native_core_service(bool restart,
                                int wait_ms) {
   if (!native_core_service_available())
     return false;
-  const std::string socket =
-      requested_socket.empty() ? backend_socket_path() : requested_socket;
+  const std::string socket = resolved_socket_path(requested_socket);
   if (!run_user_service_action(restart ? "restart" : "start"))
     return false;
   const auto deadline =
@@ -181,8 +298,7 @@ bool start_native_core_service(bool restart,
 
 pid_t start_native_core(const std::string &requested_socket,
                         const std::filesystem::path &requested_config) {
-  const std::string socket =
-      requested_socket.empty() ? backend_socket_path() : requested_socket;
+  const std::string socket = resolved_socket_path(requested_socket);
   const auto config =
       requested_config.empty() ? runtime_config_path() : requested_config;
   const auto bundled = runtime_root();
@@ -221,26 +337,146 @@ pid_t start_native_core(const std::string &requested_socket,
   return child;
 }
 
-bool ensure_native_core(const std::string &requested_socket,
-                        const std::filesystem::path &config_path, int wait_ms) {
+std::string native_core_last_error(const std::string &requested_socket) {
+  const std::string socket = resolved_socket_path(requested_socket);
+  std::lock_guard lock(native_core_error_mutex);
+  const auto found = native_core_errors.find(socket);
+  return found == native_core_errors.end() ? std::string() : found->second;
+}
+
+NativeCoreEnsureResult
+ensure_native_core_status(const std::string &requested_socket,
+                          const std::filesystem::path &config_path,
+                          int wait_ms) {
   static std::mutex ensure_mutex;
   std::lock_guard ensure_lock(ensure_mutex);
-  const std::string socket =
-      requested_socket.empty() ? backend_socket_path() : requested_socket;
+  const std::string socket = resolved_socket_path(requested_socket);
+  clear_native_core_error(socket);
   if (native_core_ready(socket))
-    return true;
+    return {true, {}, -1};
+
   if (native_core_service_available() &&
-      start_native_core_service(false, socket, wait_ms))
-    return true;
-  if (start_native_core(socket, config_path) < 0)
-    return false;
-  const auto deadline =
-      std::chrono::steady_clock::now() + std::chrono::milliseconds(wait_ms);
+      start_native_core_service(false, socket, wait_ms)) {
+    clear_native_core_error(socket);
+    return {true, {}, -1};
+  }
+
+  const auto config = config_path.empty() ? runtime_config_path() : config_path;
+  const auto bundled = runtime_root();
+  const std::string executable = find_executable(
+      "vocotype-core",
+      {bundled.empty() ? std::filesystem::path{} : bundled / "bin/vocotype-core",
+       home_path() / ".local/lib/vocotype-streaming/bin/vocotype-core",
+       home_path() / ".local/lib/vocotype-native/bin/vocotype-core",
+       "/usr/libexec/vocotype-core", "/usr/lib/vocotype/vocotype-core",
+       "/usr/lib64/vocotype/vocotype-core"});
+  if (executable.empty()) {
+    const std::string error =
+        "native core failed to start: vocotype-core executable was not found";
+    remember_native_core_error(socket, error);
+    return {false, error, 127};
+  }
+
+  int descriptors[2];
+  if (vocotype::common::create_pipe_close_on_exec(descriptors) != 0) {
+    const std::string error =
+        std::string("native core failed to start: cannot create stderr pipe: ") +
+        std::strerror(errno);
+    remember_native_core_error(socket, error);
+    return {false, error, -1};
+  }
+
+  const pid_t child = fork();
+  if (child < 0) {
+    const int fork_error = errno;
+    ::close(descriptors[0]);
+    ::close(descriptors[1]);
+    const std::string error =
+        std::string("native core failed to start: cannot fork: ") +
+        std::strerror(fork_error);
+    remember_native_core_error(socket, error);
+    return {false, error, -1};
+  }
+  if (child == 0) {
+    ::close(descriptors[0]);
+    (void)::dup2(descriptors[1], STDERR_FILENO);
+    ::close(descriptors[1]);
+    vocotype::common::set_parent_death_signal(SIGTERM);
+    if (getppid() == 1)
+      _exit(125);
+    const std::string config_string = config.string();
+    if (std::filesystem::is_regular_file(config)) {
+      execl(executable.c_str(), executable.c_str(), "--enable-final-asr",
+            "--config", config_string.c_str(), "--socket-path", socket.c_str(),
+            static_cast<char *>(nullptr));
+    } else {
+      execl(executable.c_str(), executable.c_str(), "--enable-final-asr",
+            "--socket-path", socket.c_str(), static_cast<char *>(nullptr));
+    }
+    dprintf(STDERR_FILENO, "exec %s failed: %s\n", executable.c_str(),
+            std::strerror(errno));
+    _exit(127);
+  }
+
+  ::close(descriptors[1]);
+  const int flags = ::fcntl(descriptors[0], F_GETFL, 0);
+  if (flags >= 0)
+    (void)::fcntl(descriptors[0], F_SETFL, flags | O_NONBLOCK);
+
+  std::string stderr_text;
+  const int bounded_wait = std::max(1, wait_ms);
+  const auto deadline = std::chrono::steady_clock::now() +
+                        std::chrono::milliseconds(bounded_wait);
   while (std::chrono::steady_clock::now() < deadline) {
-    if (native_core_ready(socket, 800))
-      return true;
+    stderr_text += read_available(descriptors[0]);
+    if (native_core_ready(socket, 800)) {
+      clear_native_core_error(socket);
+      detach_core_reaper(child, descriptors[0]);
+      return {true, {}, -1};
+    }
+    int status = 0;
+    const pid_t waited = ::waitpid(child, &status, WNOHANG);
+    if (waited == child) {
+      stderr_text += read_available(descriptors[0]);
+      ::close(descriptors[0]);
+      const std::string error = child_failure_message(status, stderr_text);
+      remember_native_core_error(socket, error);
+      const int exit_code = WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+      return {false, error, exit_code};
+    }
+    if (waited < 0 && errno != EINTR) {
+      const int wait_error = errno;
+      ::close(descriptors[0]);
+      const std::string error =
+          std::string("native core failed to start: waitpid failed: ") +
+          std::strerror(wait_error);
+      remember_native_core_error(socket, error);
+      return {false, error, -1};
+    }
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
   }
-  return false;
+
+  if (native_core_ready(socket, 800)) {
+    clear_native_core_error(socket);
+    detach_core_reaper(child, descriptors[0]);
+    return {true, {}, -1};
+  }
+
+  const int status = terminate_child(child);
+  stderr_text += read_available(descriptors[0]);
+  ::close(descriptors[0]);
+  std::string error = "native core did not become ready within " +
+                      std::to_string(bounded_wait) + " ms";
+  const std::string details = compact_error(stderr_text);
+  if (!details.empty())
+    error += ": " + details;
+  remember_native_core_error(socket, error);
+  const int exit_code = WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+  return {false, error, exit_code};
+}
+
+bool ensure_native_core(const std::string &requested_socket,
+                        const std::filesystem::path &config_path, int wait_ms) {
+  return ensure_native_core_status(requested_socket, config_path, wait_ms).ready;
 }
 } // namespace vocotype::desktop

--- a/src/desktop/tests/fake_native_core.cpp
+++ b/src/desktop/tests/fake_native_core.cpp
@@ -1,0 +1,76 @@
+#include <cerrno>
+#include <csignal>
+#include <cstring>
+#include <string>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+namespace {
+volatile sig_atomic_t running = 1;
+void stop(int) { running = 0; }
+}
+
+int main(int argc, char **argv) {
+  std::string socket_path;
+  for (int index = 1; index + 1 < argc; ++index) {
+    if (std::string(argv[index]) == "--socket-path") {
+      socket_path = argv[index + 1];
+      break;
+    }
+  }
+  if (socket_path.empty())
+    return 2;
+
+  std::signal(SIGTERM, stop);
+  std::signal(SIGINT, stop);
+  (void)::unlink(socket_path.c_str());
+
+  const int listener = ::socket(AF_UNIX, SOCK_STREAM, 0);
+  if (listener < 0)
+    return 3;
+  sockaddr_un address{};
+  address.sun_family = AF_UNIX;
+  if (socket_path.size() >= sizeof(address.sun_path)) {
+    ::close(listener);
+    return 4;
+  }
+  std::memcpy(address.sun_path, socket_path.c_str(), socket_path.size() + 1);
+  if (::bind(listener, reinterpret_cast<sockaddr *>(&address), sizeof(address)) !=
+      0) {
+    ::close(listener);
+    return 5;
+  }
+  if (::listen(listener, 8) != 0) {
+    ::close(listener);
+    (void)::unlink(socket_path.c_str());
+    return 6;
+  }
+
+  while (running) {
+    const int client = ::accept(listener, nullptr, nullptr);
+    if (client < 0) {
+      if (errno == EINTR)
+        continue;
+      break;
+    }
+    char buffer[4096];
+    const ssize_t count = ::recv(client, buffer, sizeof(buffer), 0);
+    const std::string request =
+        count > 0 ? std::string(buffer, static_cast<std::size_t>(count))
+                  : std::string();
+    const bool shutdown = request.find("\"type\":\"shutdown\"") !=
+                          std::string::npos;
+    const std::string response = shutdown
+                                     ? "{\"success\":true}"
+                                     : "{\"success\":true,\"pong\":true,\"backend\":\"cpp\"}";
+    (void)::send(client, response.data(), response.size(), 0);
+    ::close(client);
+    if (shutdown)
+      running = 0;
+  }
+
+  ::close(listener);
+  (void)::unlink(socket_path.c_str());
+  return 0;
+}

--- a/src/desktop/tests/ipc_core_start_tests.cpp
+++ b/src/desktop/tests/ipc_core_start_tests.cpp
@@ -1,0 +1,138 @@
+#include "vocotype/desktop/ipc.hpp"
+
+#include <chrono>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <unistd.h>
+
+namespace {
+
+bool require(bool condition, const std::string &message) {
+  if (!condition)
+    std::cerr << "FAIL: " << message << '\n';
+  return condition;
+}
+
+std::filesystem::path make_temp_directory() {
+  std::string pattern = "/tmp/vocotype-ipc-start-XXXXXX";
+  char *created = ::mkdtemp(pattern.data());
+  if (!created)
+    throw std::runtime_error("mkdtemp failed");
+  return created;
+}
+
+bool wait_for_socket_removal(const std::filesystem::path &socket) {
+  for (int attempt = 0; attempt < 50; ++attempt) {
+    if (!std::filesystem::exists(socket))
+      return true;
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  }
+  return !std::filesystem::exists(socket);
+}
+
+} // namespace
+
+int main(int argc, char **argv) {
+  if (argc != 2) {
+    std::cerr << "usage: ipc_core_start_tests FAKE_CORE\n";
+    return 2;
+  }
+
+  const std::filesystem::path fake_core =
+      std::filesystem::canonical(argv[1]);
+  const std::filesystem::path temporary = make_temp_directory();
+  const std::filesystem::path home = temporary / "home";
+  const std::filesystem::path bin = temporary / "bin";
+  std::filesystem::create_directories(home);
+  std::filesystem::create_directories(bin);
+
+  const char *old_path_value = std::getenv("PATH");
+  const std::string old_path = old_path_value ? old_path_value : "";
+  const std::string path = bin.string() + (old_path.empty() ? "" : ":" + old_path);
+  ::setenv("HOME", home.c_str(), 1);
+  ::setenv("PATH", path.c_str(), 1);
+  ::unsetenv("VOCOTYPE_RUNTIME_DIR");
+  ::unsetenv("VOCOTYPE_CONFIG");
+
+  bool success = true;
+
+  const std::filesystem::path executable = bin / "vocotype-core";
+  std::filesystem::create_symlink(fake_core, executable);
+  const std::string success_socket =
+      "/tmp/vocotype-ipc-success-" + std::to_string(::getpid()) + ".sock";
+  std::filesystem::remove(success_socket);
+
+  const auto cold_start = vocotype::desktop::ensure_native_core_status(
+      success_socket, {}, 5000);
+  success &= require(cold_start.ready,
+                     "cold-start fixture should become ready: " +
+                         cold_start.error);
+  if (cold_start.ready) {
+    const auto ping = vocotype::desktop::unix_json_request(
+        success_socket, {{"type", "ping"}}, 1000);
+    success &= require(ping.value("success", false) &&
+                           ping.value("pong", false) &&
+                           ping.value("backend", "") == "cpp",
+                       "cold-started core should answer ping");
+    (void)vocotype::desktop::unix_json_request(
+        success_socket, {{"type", "shutdown"}}, 1000);
+    success &= require(wait_for_socket_removal(success_socket),
+                       "fake core should remove its socket on shutdown");
+  }
+
+  std::filesystem::remove(executable);
+  {
+    std::ofstream script(executable);
+    script << "#!/bin/sh\n"
+              "echo 'fixture startup failure' >&2\n"
+              "exit 42\n";
+  }
+  std::filesystem::permissions(
+      executable,
+      std::filesystem::perms::owner_read |
+          std::filesystem::perms::owner_write |
+          std::filesystem::perms::owner_exec,
+      std::filesystem::perm_options::replace);
+
+  const std::string failure_socket =
+      "/tmp/vocotype-ipc-failure-" + std::to_string(::getpid()) + ".sock";
+  std::filesystem::remove(failure_socket);
+  const auto failed_start = vocotype::desktop::ensure_native_core_status(
+      failure_socket, {}, 3000);
+  success &= require(!failed_start.ready,
+                     "failing fixture must not be reported ready");
+  success &= require(failed_start.exit_code == 42,
+                     "failing fixture exit code should be preserved");
+  success &= require(
+      failed_start.error.find("fixture startup failure") != std::string::npos,
+      "startup stderr should be preserved in the failure");
+  success &= require(
+      vocotype::desktop::native_core_last_error(failure_socket) ==
+          failed_start.error,
+      "last startup error should remain associated with the socket");
+
+  try {
+    (void)vocotype::desktop::unix_json_request(
+        failure_socket, {{"type", "transcribe"}}, 100);
+    success &= require(false, "request after failed cold-start must fail");
+  } catch (const std::exception &error) {
+    const std::string message = error.what();
+    success &= require(
+        message.find("fixture startup failure") != std::string::npos,
+        "request should surface the original startup failure");
+    success &= require(message.find("No such file") == std::string::npos,
+                       "request must not degrade to ENOENT after startup failure");
+  }
+
+  std::filesystem::remove(failure_socket);
+  std::filesystem::remove_all(temporary);
+  if (!success)
+    return 1;
+  std::cout << "IPC_CORE_COLD_START_OK\n";
+  return 0;
+}


### PR DESCRIPTION
Fixes #54.

- preserve the original native-core startup failure instead of degrading to `cannot connect ... No such file or directory`
- capture direct-launch stderr and exit status
- keep readiness probes able to recover if the core later becomes available
- add cold-start success and fail-closed regression coverage, including an assertion that ENOENT is not surfaced after a known startup failure

CI should compile the new desktop regression along with the existing package/integration gates.